### PR TITLE
Update bug in slides

### DIFF
--- a/slides.html
+++ b/slides.html
@@ -902,7 +902,7 @@
         ```javascript
         var exampleOne = 5;
         var exampleTwo = 2;
-        var endValue = exampleOne * exampleOne; // will return a value of 10
+        var endValue = exampleOne * exampleTwo; // will return a value of 10
         ```
         
       </script>


### PR DESCRIPTION
Had multiplication of exampleOne twice (equalling 25)  instead of exampleOne \* exampleTwo (equalling the expected 10 as per comment)
