### PR TITLE
Simplify the introduction of variables

### DIFF
--- a/slides.html
+++ b/slides.html
@@ -576,18 +576,18 @@
         Declare (create) variables with the keyword `var` and give it a name.
         
         ```
-        var firstname;
+        var name;
         ```
 
         Assign a value to the variable using the equals `=` symbol. Remember, to end the statement with a semicolon. Now the computer will remember your name!
 
         ```
-        firstname = "Yourname";
+        name = "Yourname";
         ```
         You can also assign a value and declare a variable at the same time.
         
         ```
-        var firstname = "Yourname";
+        var name = "Yourname";
         ```
       </script>
     </section>
@@ -606,8 +606,8 @@
         It can also output the value of the variable. Note that the variable doesn't require quotes.
         
         ```
-        var firstname = "Yourname";
-        document.write(firstname); // will output "Yourname" onto the page.
+        var name = "Yourname";
+        document.write(name); // will output "Yourname" onto the page.
         ```
       </script>
     </section>
@@ -616,10 +616,10 @@
       <script type="text/template">
         # Variables and user input
         
-        The previous example showed how to assign a specific value to the `firstname` variable. 
+        The previous example showed how to assign a specific value to the `name` variable. 
         
         ```
-        var firstname = "Yourname";
+        var name = "Yourname";
         ```
         
         But what if we don't know what that value is going to be?
@@ -642,8 +642,9 @@
           </li>
           <li class="delayed">
             <p>Remember my name</p>
-            <code class="delayed">var firstname = ?</code>
-            <code class="delayed">var firstname = prompt("What is your name?");</code>
+            <code class="delayed">var name = ?</code>
+            <br>
+            <code class="delayed">var name = prompt("What is your name?");</code>
           </li>
         </ol>
         

--- a/slides.html
+++ b/slides.html
@@ -1704,7 +1704,7 @@ function moreLove(){
         ##Execute the Add button function when the Add button is clicked.
         ---
         
-        What do we want to happen onclick?  To run the `addItem()` function!  They syntax to run a function with this property is a little different than the previous examples.
+        What do we want to happen onclick?  To run the `addItem()` function!  The syntax to run a function with this property is a little different than the previous examples.
 
         According to the [documentation](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onclick), the syntax is as follows:
         


### PR DESCRIPTION
After teaching this workshop, I've encountered a few complications for students to follow the slides during the introduction of variables.

At slide 37, students are introduced to the variable notation using the `name` variable. Students are then encouraged to follow along through slide 38 to 41 to discover variable declarations with the `fullname` variable. 

Students face the following complications during this portion of the course.
1. They are introduced to non-camel case variable notation, which in the next chapter is introduced.
2. While following along, students at slide 42 attempt to write a statement to "remember my name", however, being new they inherently copy the content on the slide which results in their code to look like `var name = ? var name = prompt("What is your name?");`
3. Once students become comfortable with this notation, they face an issue when slide 42 changes the variable from `fullname` to `name` and result in the `document.write(name);` statement to output `undefined`.
4. There is a typo on slide 94.

The solution to resolve this issues is the following.
1. Rename all `fullname` variables to `name`.
2. Add a line break to slide 41 between both statements under point 2.
3. A typo was resolved on slide 94.
